### PR TITLE
Fix the abstration remaining method

### DIFF
--- a/src/Md5Hash.php
+++ b/src/Md5Hash.php
@@ -7,6 +7,17 @@ use Illuminate\Contracts\Hashing\Hasher;
 class Md5Hash implements Hasher
 {
     /**
+     * Get information about the given hashed value.
+     *
+     * @param  string  $hashedValue
+     * @return array
+     */
+    public function info($hashedValue)
+    {
+        return $hashedValue;
+    }
+    
+    /**
      * Hash the given value.
      *
      * @param  string $value


### PR DESCRIPTION
Fix error:

Class 'Matriphe\Md5Hash\Manager' not found in /home/marcus-campos/Documentos/projects/saidcs/new-saidjur-central/vendor/matriphe/laravel-md5-hash/src/Md5Hash.php on line 7