### PR TITLE
Return array in info() to satisfy interface

### DIFF
--- a/src/Md5Hash.php
+++ b/src/Md5Hash.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Hashing\Hasher;
 
 class Md5Hash implements Hasher
 {
+	const ALGO = 'md5';
+
     /**
      * Get information about the given hashed value.
      *
@@ -14,7 +16,7 @@ class Md5Hash implements Hasher
      */
     public function info($hashedValue)
     {
-        return ['hashed' => $hashedValue, 'algo' => 'md5'];
+        return ['hashed' => $hashedValue, 'algo' => self::ALGO];
     }
     
     /**
@@ -26,7 +28,7 @@ class Md5Hash implements Hasher
      */
     public function make($value, array $options = [])
     {
-        return hash('md5', $value);
+        return hash(self::ALGO, $value);
     }
 
     /**

--- a/src/Md5Hash.php
+++ b/src/Md5Hash.php
@@ -14,7 +14,7 @@ class Md5Hash implements Hasher
      */
     public function info($hashedValue)
     {
-        return $hashedValue;
+        return ['hashed' => $hashedValue];
     }
     
     /**

--- a/src/Md5Hash.php
+++ b/src/Md5Hash.php
@@ -14,7 +14,7 @@ class Md5Hash implements Hasher
      */
     public function info($hashedValue)
     {
-        return ['hashed' => $hashedValue];
+        return ['hashed' => $hashedValue, 'algo' => 'md5'];
     }
     
     /**

--- a/tests/HashTest.php
+++ b/tests/HashTest.php
@@ -2,11 +2,17 @@
 
 namespace Matriphe\Md5Hash\Test;
 
+use Illuminate\Contracts\Hashing\Hasher;
 use Matriphe\Md5Hash\Md5Hash;
 use PHPUnit\Framework\TestCase;
 
 class HashTest extends TestCase
 {
+	/**
+	 * @var Hasher
+	 */
+	private $hash;
+
     public function setUp()
     {
         parent::setUp();
@@ -38,4 +44,17 @@ class HashTest extends TestCase
     {
         $this->assertFalse($this->hash->needsRehash(md5('matriphe')));
     }
+
+	/**
+	 * @test
+	 */
+	public function info_function_returns_an_array()
+	{
+		$this->assertEquals(
+			['hashed' => 'matriphe', 'algo' => 'md5'],
+			$this->hash->info('matriphe')
+		);
+	}
+
+
 }


### PR DESCRIPTION
This PR fixed returned value for `info()` method.

It fixes #6