### PR TITLE
Add Laravel 8 Support

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ on:
       - synchronize
 
 jobs:
-  test:
+  test_laravel_6_7:
     name: Laravel ${{ matrix.laravel-versions }} (PHP ${{ matrix.php-versions }})
     strategy:
       fail-fast: false
@@ -15,6 +15,20 @@ jobs:
         operating-system: [ ubuntu-latest ]
         php-versions: [ '7.2', '7.3', '7.4', '8.0' ]
         laravel-versions: [ '6.*', '7.*' ]
+    uses: matriphe/laravel-md5-hash/.github/workflows/laravel_test.yml@master
+    with:
+      operating_system: ${{ matrix.operating-system }}
+      php_version: ${{ matrix.php-versions }}
+      laravel_version: ${{ matrix.laravel-versions }}
+
+  test_laravel_8_9:
+    name: Laravel ${{ matrix.laravel-versions }} (PHP ${{ matrix.php-versions }})
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-latest ]
+        php-versions: [ '7.3', '7.4', '8.0' ]
+        laravel-versions: [ '8.*' ]
     uses: matriphe/laravel-md5-hash/.github/workflows/laravel_test.yml@master
     with:
       operating_system: ${{ matrix.operating-system }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,13 +21,13 @@ jobs:
       php_version: ${{ matrix.php-versions }}
       laravel_version: ${{ matrix.laravel-versions }}
 
-  test_laravel_8_9:
+  test_laravel_8:
     name: Laravel ${{ matrix.laravel-versions }} (PHP ${{ matrix.php-versions }})
     strategy:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-versions: [ '7.3', '7.4', '8.0' ]
+        php-versions: [ '7.3', '7.4', '8.0', '8.1' ]
         laravel-versions: [ '8.*' ]
     uses: matriphe/laravel-md5-hash/.github/workflows/laravel_test.yml@master
     with:

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,10 @@
         "password"
     ],
     "require": {
-        "laravel/framework": "6.*|7.*"
+        "laravel/framework": "6.*|7.*|8.*"
     },
     "require-dev": {
-        "orchestra/testbench": "4.*|5.*"
+        "orchestra/testbench": "4.*|5.*|6.*"
     },
     "license": "MIT",
     "authors": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="MD5Hash Test Suite">


### PR DESCRIPTION
This PR adds support for Laravel 8.

And also it [removes the `syntaxCheck` from PHP Unit](https://stackoverflow.com/questions/44328114/phpunit-what-does-syntaxcheck-configuration-parameter-stands-for-exactly).